### PR TITLE
Table of Contents, WinSCP and Missing Step

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,6 @@ mtd -p 0x200000 write /tmp/FW_E8450_1.0.01.101415_prod.img /dev/mtd3
 mtd -p 0x200000 write /tmp/FW_RT3200_1.0.01.101415_prod.img /dev/mtd3
 ```
 4. Reboot the device and wait about a minute for it to be ready.
-5. If you use the [**complete backup**](#device-flash-backup-procedure-while-running-the-stock-firmware-version-10), after reboot the router will boot into the **initramfs system**, you will need **perform a powercycle** to reboot into the original/vendor firmware (**to perform a powercycle**, unplug the device from the power source for about 30 seconds before plugging it back).
+5. If you use the [**complete backup**](#device-flash-backup-procedure-while-running-the-stock-firmware-version-10), after rebooting, the router will boot into the **initramfs system**, you will need **perform a powercycle** to reboot into the original/vendor firmware (**to perform a powercycle**, unplug the device from the power source for about 30 seconds before plugging it back).
 
 **Note:** Be prepared to connect the serial console as bad blocks are **not** handled in the way the stock firmware and loader expects it. Ie. if you are lucky enough to own a device which got a bad block in the first ~22MiB of the SPI-NAND flash, then you will need to flash using TFTP which can only be triggered using the boot menu accessible via the serial console.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,6 @@ mtd -p 0x200000 write /tmp/FW_E8450_1.0.01.101415_prod.img /dev/mtd3
 mtd -p 0x200000 write /tmp/FW_RT3200_1.0.01.101415_prod.img /dev/mtd3
 ```
 4. Reboot the device and wait about a minute for it to be ready.
-5. If you use the [**complete backup**](#device-flash-backup-procedure-while-running-the-stock-firmware-version-10), after reboot the router will boot into the **initramfs system** and need **perform a powercycle** to reboot into the original/vendor firmware (**to perform a powercycle**, unplug the device from the power source for about 30 seconds before plugging it back).
+5. If you use the [**complete backup**](#device-flash-backup-procedure-while-running-the-stock-firmware-version-10), after reboot the router will boot into the **initramfs system**, you will need **perform a powercycle** to reboot into the original/vendor firmware (**to perform a powercycle**, unplug the device from the power source for about 30 seconds before plugging it back).
 
 **Note:** Be prepared to connect the serial console as bad blocks are **not** handled in the way the stock firmware and loader expects it. Ie. if you are lucky enough to own a device which got a bad block in the first ~22MiB of the SPI-NAND flash, then you will need to flash using TFTP which can only be triggered using the boot menu accessible via the serial console.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,19 @@ https://user-images.githubusercontent.com/82453643/147394017-e7af122c-8234-4f11-
 
 **WARNING #2** Re-flashing the installer when the device is already using UBI flash layout will erase the previously backed up bootchain, which in most cases would be the vendor/official one.
 
-It's recommended that you make a **complete backup** of the device flash __**before**__ running the installer. (see below "[Device flash backup procedure while running the stock firmware version 1.0](#device-flash-backup-procedure-while-running-the-stock-firmware-version-10)")
+It's recommended that you make a **complete backup** of the device flash __**before**__ running the installer. (see below "[Device flash backup procedure](#device-flash-backup-procedure-while-running-the-stock-firmware-version-10)")
 
-### Script information
+## Table of Contents
+* [Script information](#script-information)
+* [Downgrade firmware](#downgrade-firmware)
+* [Device flash backup procedure](#device-flash-backup-procedure-while-running-the-stock-firmware-version-10)
+* [Installing OpenWrt](#installing-openwrt)
+* [Upgrading to the latest OpenWrt snapshot](#upgrading-to-the-latest-openwrt-snapshot)
+* [Enter recovery mode under OpenWrt](#enter-recovery-mode-under-openwrt)
+* [Restoring the vendor/official firmware](#restoring-the-vendorofficial-firmware)
+
+
+## Script information
 
 This script downloads the OpenWrt ImageBuilder to generate a release-like (i.e. LuCI included) *sysupgrade* image. The process involves re-packaging the *initramfs* image to contain everything necessary for a permanent recovery image within the NAND flash, including the installer script and the prerequisite installation images.
 
@@ -28,7 +38,7 @@ You'll need the below to use the script to generate the installer image:
  * For Linksys E8450 [FW_E8450_1.0.01.101415_prod.img](https://downloads.linksys.com/support/assets/firmware/FW_E8450_1.0.01.101415_prod.img)
  * For Belkin RT3200 [FW_RT3200_1.0.01.101415_prod.img](https://www.belkin.com/support/assets/belkin/firmware/FW_RT3200_1.0.01.101415_prod.img)
 
-## Device flash backup procedure while running the stock firmware version 1.0
+## Device flash backup procedure (while running the stock firmware version 1.0)
 
 1. Flash `openwrt-mediatek-mt7622-linksys_e8450-ubi-initramfs-recovery.itb` (note that this file doesn't have the word _installer_ in its filename)
 2. Login [http://192.168.1.1](http://192.168.1.1/cgi-bin/luci/admin/system/flash), then navigate to **System -> Backup / Flash Firmware** and save a copy of each of the `mtdblock`.
@@ -41,8 +51,8 @@ for part in mtd[0123] ; do
 done
 ```
 
-4. Then, copy the resulting **mtdx** files found in the `/tmp` folder on the router to the computer using **scp** (the size of the *mtd3* file has to be **125MB** and make sure the size of the other files is the same, when you copy them to the computer).
-5. **Perform a powercycle** to reboot into the original non-ubi firmware (**to perform a powercycle**, unplug the device from the power source for about 30 seconds before plugging it back).
+4. Then, copy the resulting **mtdx** files found in the `/tmp` folder on the router to the computer using **scp** or [WinSCP](https://winscp.net/eng/downloads.php) (the size of the *mtd3* file has to be **125MB** and make sure the size of the other files is the same, when you copy them to the computer).
+5. **Perform a powercycle** to reboot into the original/vendor firmware (**to perform a powercycle**, unplug the device from the power source for about 30 seconds before plugging it back).
 6. When the device is running **original/vendor firmware**, perform a factory reset.
 
 Do not attempt to flash `openwrt-mediatek-mt7622-linksys_e8450-ubi-initramfs-recovery-installer.itb` from the running **initramfs system** -- it will fail to reboot, possibly requiring serial console access. Instead, **powercycle** the device to reboot into the original non-ubi firmware, and then flash the `installer` version.
@@ -83,7 +93,7 @@ PROCEED AT YOUR OWN RISK!
 
 2. Both `auc` (attended sysupgrade command-line client) and `luci-app-attendedsysupgrade` (LuCI web-interface counterpart) are included since version 0.6. Simply run `auc` from the command-line, or navigate to __System__ -> __Attended Sysupgrade__ and proceed accordingly.
 
-## To enter recovery mode under OpenWrt
+## Enter recovery mode under OpenWrt
 
 1. Hold down the "reset" button (below the "WPS" button) whilst powering on the device.
 2. Release the button once the power LED turns into orange/yellow.
@@ -94,7 +104,7 @@ This will remove any user configuration and allow restoring or upgrading from [s
 ## Restoring the vendor/official firmware ##
 
 1. Boot into recovery mode, either by flashing `openwrt-mediatek-mt7622-linksys_e8450-ubi-initramfs-recovery.itb` (note that this file doesn't have the word _installer_ in its filename) *or* by holding the RESET button while connecting the device to power *or* by issuing `echo c > /proc/sysrq-trigger` while running the production firmware. 
-2. Use *scp* to copy the *mtdx* files to the `/tmp` folder on the router (the [complete backup](#device-flash-backup-procedure-while-running-the-stock-firmware-version-10) that you have on your computer), which is the **original/vendor bootchain and firmware** (the size of the *mtd3* file has to be **125MB** and make sure the size of the other files is the same, when you copy them to the router). In case you only got the **[minimal backup](#upgrading-to-the-latest-openwrt-snapshot)**, also upload the **[vendor firmware](#downgrade-firmware)**.
+2. Use **scp** or [WinSCP](https://winscp.net/eng/downloads.php) to copy the *mtdx* files to the `/tmp` folder on the router (the [**complete backup**](#device-flash-backup-procedure-while-running-the-stock-firmware-version-10) that you have on your computer), which is the **original/vendor bootchain and firmware** (the size of the *mtd3* file has to be **125MB** and make sure the size of the other files is the same, when you copy them to the router). In case you only got the [**minimal backup**](#upgrading-to-the-latest-openwrt-snapshot) (*mtd3* file size is **2MB**), also upload the [**original/vendor firmware**](#downgrade-firmware).
 3. Connect to the device via SSH and enter the following commands:
 ```
 ubidetach -d 0
@@ -104,13 +114,15 @@ mtd write /tmp/mtd1 /dev/mtd1
 mtd write /tmp/mtd2 /dev/mtd2
 mtd write /tmp/mtd3 /dev/mtd3
 ```
-In case you were using the **[minimal backup](#upgrading-to-the-latest-openwrt-snapshot)** files, now write the main firmware:
+In case you were using the [**minimal backup**](#upgrading-to-the-latest-openwrt-snapshot) files, now write the **original/vendor firmware**:
 ```
-# on Linksys E8450
+# On Linksys E8450
 mtd -p 0x200000 write /tmp/FW_E8450_1.0.01.101415_prod.img /dev/mtd3
-# on Belkin RT3200
+
+# On Belkin RT3200
 mtd -p 0x200000 write /tmp/FW_RT3200_1.0.01.101415_prod.img /dev/mtd3
 ```
 4. Reboot the device and wait about a minute for it to be ready.
+5. If you use the [**complete backup**](#device-flash-backup-procedure-while-running-the-stock-firmware-version-10), after reboot the router will boot into the **initramfs system** and need **perform a powercycle** to reboot into the original/vendor firmware (**to perform a powercycle**, unplug the device from the power source for about 30 seconds before plugging it back).
 
 **Note:** Be prepared to connect the serial console as bad blocks are **not** handled in the way the stock firmware and loader expects it. Ie. if you are lucky enough to own a device which got a bad block in the first ~22MiB of the SPI-NAND flash, then you will need to flash using TFTP which can only be triggered using the boot menu accessible via the serial console.


### PR DESCRIPTION
1. Add "Table of Contents" to make it move through sections.
2. Add "WinSCP" for people using windows.
3. Add this important step 5 in "Restoring the vendor/official firmware", which is necessary to perform a powercycle after using the "complete backup".

@dangowrt