### PR TITLE
Fixing spell in section Device flash backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ https://user-images.githubusercontent.com/82453643/147394017-e7af122c-8234-4f11-
 
 **WARNING #2** Re-flashing the installer when the device is already using UBI flash layout will erase the previously backed up bootchain, which in most cases would be the vendor/official one.
 
-It's recommended that you make a **complete backup** of the device flash __**before**__ running the installer. (see below "[Device flash backup procedure](#device-flash-backup-procedure-while-running-the-stock-firmware-version-10)")
+It's recommended that you make a **complete backup** of the device flash __**before**__ running the installer. (see below "[Device flash complete backup procedure](#device-flash-complete-backup-procedure)")
 
 ## Table of Contents
 * [Script information](#script-information)
 * [Downgrade firmware](#downgrade-firmware)
-* [Device flash backup procedure](#device-flash-backup-procedure-while-running-the-stock-firmware-version-10)
+* [Device flash complete backup procedure](#device-flash-complete-backup-procedure)
 * [Installing OpenWrt](#installing-openwrt)
 * [Upgrading to the latest OpenWrt snapshot](#upgrading-to-the-latest-openwrt-snapshot)
 * [Enter recovery mode under OpenWrt](#enter-recovery-mode-under-openwrt)
@@ -38,7 +38,9 @@ You'll need the below to use the script to generate the installer image:
  * For Linksys E8450 [FW_E8450_1.0.01.101415_prod.img](https://downloads.linksys.com/support/assets/firmware/FW_E8450_1.0.01.101415_prod.img)
  * For Belkin RT3200 [FW_RT3200_1.0.01.101415_prod.img](https://www.belkin.com/support/assets/belkin/firmware/FW_RT3200_1.0.01.101415_prod.img)
 
-## Device flash backup procedure (while running the stock firmware version 1.0)
+## Device flash complete backup procedure
+
+#### Assuming the device is running stock firmware version 1.0
 
 1. Flash `openwrt-mediatek-mt7622-linksys_e8450-ubi-initramfs-recovery.itb` (note that this file doesn't have the word _installer_ in its filename)
 2. Login [http://192.168.1.1](http://192.168.1.1/cgi-bin/luci/admin/system/flash), then navigate to **System -> Backup / Flash Firmware** and save a copy of each of the `mtdblock`.
@@ -104,7 +106,7 @@ This will remove any user configuration and allow restoring or upgrading from [s
 ## Restoring the vendor/official firmware ##
 
 1. Boot into recovery mode, either by flashing `openwrt-mediatek-mt7622-linksys_e8450-ubi-initramfs-recovery.itb` (note that this file doesn't have the word _installer_ in its filename) *or* by holding the RESET button while connecting the device to power *or* by issuing `echo c > /proc/sysrq-trigger` while running the production firmware. 
-2. Use **scp** or [WinSCP](https://winscp.net/eng/downloads.php) to copy the *mtdx* files to the `/tmp` folder on the router (the [**complete backup**](#device-flash-backup-procedure-while-running-the-stock-firmware-version-10) that you have on your computer), which is the **original/vendor bootchain and firmware** (the size of the *mtd3* file has to be **125MB** and make sure the size of the other files is the same, when you copy them to the router). In case you only got the [**minimal backup**](#upgrading-to-the-latest-openwrt-snapshot) (*mtd3* file size is **2MB**), also upload the [**original/vendor firmware**](#downgrade-firmware).
+2. Use **scp** or [WinSCP](https://winscp.net/eng/downloads.php) to copy the *mtdx* files to the `/tmp` folder on the router (the [**complete backup**](#device-flash-complete-backup-procedure) that you have on your computer), which is the **original/vendor bootchain and firmware** (the size of the *mtd3* file has to be **125MB** and make sure the size of the other files is the same, when you copy them to the router). In case you only got the [**minimal backup**](#upgrading-to-the-latest-openwrt-snapshot) (*mtd3* file size is **2MB**), also upload the [**original/vendor firmware**](#downgrade-firmware).
 3. Connect to the device via SSH and enter the following commands:
 ```
 ubidetach -d 0
@@ -123,6 +125,6 @@ mtd -p 0x200000 write /tmp/FW_E8450_1.0.01.101415_prod.img /dev/mtd3
 mtd -p 0x200000 write /tmp/FW_RT3200_1.0.01.101415_prod.img /dev/mtd3
 ```
 4. Reboot the device and wait about a minute for it to be ready.
-5. If you use the [**complete backup**](#device-flash-backup-procedure-while-running-the-stock-firmware-version-10), after rebooting, the router will boot into the **initramfs system**, you will need **perform a powercycle** to reboot into the original/vendor firmware (**to perform a powercycle**, unplug the device from the power source for about 30 seconds before plugging it back).
+5. If you use the [**complete backup**](#device-flash-complete-backup-procedure), after rebooting, the router will boot into the **initramfs system**, you will need **perform a powercycle** to reboot into the original/vendor firmware (**to perform a powercycle**, unplug the device from the power source for about 30 seconds before plugging it back).
 
 **Note:** Be prepared to connect the serial console as bad blocks are **not** handled in the way the stock firmware and loader expects it. Ie. if you are lucky enough to own a device which got a bad block in the first ~22MiB of the SPI-NAND flash, then you will need to flash using TFTP which can only be triggered using the boot menu accessible via the serial console.


### PR DESCRIPTION
1. Renamed section "**Device flash backup procedure (while running the stock firmware version 1.0)**" to "**Device flash complete backup procedure**", because it looked horrible before.
2. Add in that section "**Assuming the device is running stock firmware version 1.0**".

@dangowrt 